### PR TITLE
Handle NaT values before serializing occurrences

### DIFF
--- a/app.py
+++ b/app.py
@@ -104,7 +104,12 @@ def get_ocorrencias():
   if df_filtrado.empty:
     return jsonify([])
 
-  df_limpo = df_filtrado.where(pd.notnull(df_filtrado), None)
+  df_limpo = df_filtrado.copy()
+  datetime_cols = df_limpo.select_dtypes(include=['datetime64[ns]', 'datetime64[ns, tz]']).columns
+  for col in datetime_cols:
+    df_limpo[col] = df_limpo[col].apply(lambda x: x.isoformat() if pd.notnull(x) else None)
+
+  df_limpo = df_limpo.where(pd.notnull(df_limpo), None)
   dados_para_json = df_limpo.to_dict(orient='records')
   return jsonify(dados_para_json)
 


### PR DESCRIPTION
## Summary
- copy the filtered occurrences before serialization and normalize datetime columns to ISO strings
- ensure NaT values become JSON nulls to avoid serialization errors

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68df1ef72a288325ad1a5ea0cc367909