### PR TITLE
Add dashboard close button to dashboard view

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,10 @@
 
 <section id="dashboard-panel">
   <div class="dashboard-content">
-    <h2>Dashboard de Ocorrências</h2>
+    <div class="dashboard-header">
+      <h2>Dashboard de Ocorrências</h2>
+      <button id="dashboard-close" type="button">Voltar ao mapa</button>
+    </div>
     <div class="dashboard-feedback" aria-live="polite"></div>
     <div class="dashboard-chart">
       <h3>Ocorrências por Tema</h3>

--- a/script.js
+++ b/script.js
@@ -8,6 +8,7 @@ document.addEventListener('DOMContentLoaded', () => {
   let dashboardCharts = {};
   const dashboardPanel = document.getElementById('dashboard-panel');
   const dashboardFeedback = dashboardPanel ? dashboardPanel.querySelector('.dashboard-feedback') : null;
+  const dashboardCloseButton = document.getElementById('dashboard-close');
   const map = L.map('mapa').setView([-22.3245, -49.0749], 13);
 
   L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
@@ -235,6 +236,13 @@ document.addEventListener('DOMContentLoaded', () => {
     onRemove: function(map) {}
   });
 
+  function setActiveViewButton(viewMode) {
+    const viewButtons = document.querySelectorAll('.leaflet-control-view .view-option');
+    viewButtons.forEach(btn => {
+      btn.classList.toggle('active', btn.dataset.view === viewMode);
+    });
+  }
+
   L.Control.View = L.Control.extend({
     onAdd: function(map) {
       const container = L.DomUtil.create('div', 'leaflet-control-view');
@@ -269,14 +277,14 @@ document.addEventListener('DOMContentLoaded', () => {
         button.addEventListener('click', function() {
           const newViewMode = this.dataset.view;
           if (newViewMode !== currentViewMode) {
-            viewButtons.forEach(btn => btn.classList.remove('active'));
-            this.classList.add('active');
-
             currentViewMode = newViewMode;
+            setActiveViewButton(currentViewMode);
             atualizarVisualizacao();
           }
         });
       });
+
+      setActiveViewButton(currentViewMode);
 
       return container;
     },
@@ -286,6 +294,18 @@ document.addEventListener('DOMContentLoaded', () => {
   const viewControl = new L.Control.View({ position: 'topright' }).addTo(map);
   const filterControl = new L.Control.Filter({ position: 'topright' }).addTo(map);
   const legendControl = new L.Control.Legend({ position: 'bottomleft' }).addTo(map);
+
+  if (dashboardCloseButton) {
+    dashboardCloseButton.addEventListener('click', () => {
+      if (currentViewMode !== 'markers') {
+        currentViewMode = 'markers';
+        setActiveViewButton(currentViewMode);
+        atualizarVisualizacao();
+      }
+    });
+  }
+
+  setActiveViewButton(currentViewMode);
 
   function initCustomSelects() {
     document.querySelectorAll('.select-selected').forEach(selectBtn => {
@@ -400,16 +420,14 @@ document.addEventListener('DOMContentLoaded', () => {
       return;
     }
 
-    if (currentViewMode === 'dashboard') {
-      dashboardPanel.style.display = 'block';
-      if (dashboardFeedback) {
-        dashboardFeedback.textContent = 'Carregando estatísticas...';
-      }
-    } else {
-      dashboardPanel.style.display = 'none';
-      if (dashboardFeedback) {
-        dashboardFeedback.textContent = '';
-      }
+    const dashboardAtivo = currentViewMode === 'dashboard';
+
+    dashboardPanel.style.display = dashboardAtivo ? 'block' : 'none';
+    dashboardPanel.classList.toggle('dashboard-fullscreen', dashboardAtivo);
+    document.body.classList.toggle('dashboard-open', dashboardAtivo);
+
+    if (dashboardFeedback) {
+      dashboardFeedback.textContent = dashboardAtivo ? 'Carregando estatísticas...' : '';
     }
 
     setTimeout(() => map.invalidateSize(), 200);

--- a/style.css
+++ b/style.css
@@ -22,6 +22,49 @@ body, html {
   z-index: 1000;
 }
 
+.dashboard-fullscreen {
+  position: fixed;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  transform: none;
+  border-radius: 0;
+  max-height: none;
+  overflow-y: auto;
+}
+
+#dashboard-panel .dashboard-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+#dashboard-panel #dashboard-close {
+  background-color: #2563eb;
+  color: #ffffff;
+  border: none;
+  border-radius: 8px;
+  padding: 8px 16px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s ease, transform 0.2s ease;
+}
+
+#dashboard-panel #dashboard-close:hover {
+  background-color: #1e40af;
+}
+
+#dashboard-panel #dashboard-close:focus {
+  outline: 2px solid #93c5fd;
+  outline-offset: 2px;
+}
+
+#dashboard-panel #dashboard-close:active {
+  transform: scale(0.97);
+}
+
 #dashboard-panel .dashboard-content {
   display: flex;
   flex-direction: column;
@@ -57,6 +100,10 @@ body, html {
 #mapa {
   height: 100%;
   width: 100%;
+}
+
+.dashboard-open #mapa {
+  display: none;
 }
 
 .leaflet-control-filter {


### PR DESCRIPTION
## Summary
- add a close button to the dashboard header so users can return to the map
- style the dashboard panel for fullscreen mode and hide the map while the dashboard is open
- update dashboard rendering logic to toggle new classes and handle button interaction

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e8333858d48325aae66bd50a3c5c31