### PR TITLE
Atualiza dashboard com totais únicos de ocorrências

### DIFF
--- a/app.py
+++ b/app.py
@@ -159,22 +159,36 @@ def gerar_estatisticas_dashboard(df: pd.DataFrame) -> dict:
   resultado = {
     "por_tema": [],
     "serie_mensal": [],
-    "principais_enderecos": []
+    "principais_enderecos": [],
+    "total_ocorrencias": 0
   }
 
   if df.empty:
     return resultado
 
+  def remover_duplicatas(base: pd.DataFrame, colunas_preferencia):
+    colunas_existentes = [col for col in colunas_preferencia if col in base.columns]
+    if not colunas_existentes:
+      return base.drop_duplicates()
+    return base.drop_duplicates(subset=colunas_existentes)
+
+  df_unicos = remover_duplicatas(df, ['link', 'title', 'published_date', 'tema'])
+  resultado['total_ocorrencias'] = int(len(df_unicos))
+
+  if df_unicos.empty:
+    return resultado
+
   contagem_tema = (
-    df.groupby('tema')
+    df_unicos.groupby('tema', dropna=False)
       .size()
       .reset_index(name='contagem')
       .sort_values('contagem', ascending=False)
   )
+  contagem_tema['tema'] = contagem_tema['tema'].fillna('Não informado')
   contagem_tema['contagem'] = contagem_tema['contagem'].astype(int)
   resultado['por_tema'] = contagem_tema.to_dict(orient='records')
 
-  df_mensal = df.dropna(subset=['published_date']).copy()
+  df_mensal = df_unicos.dropna(subset=['published_date']).copy()
   if not df_mensal.empty:
     df_mensal['mes'] = df_mensal['published_date'].dt.to_period('M')
     serie_mensal = (
@@ -188,7 +202,8 @@ def gerar_estatisticas_dashboard(df: pd.DataFrame) -> dict:
     resultado['serie_mensal'] = serie_mensal.to_dict(orient='records')
 
   if 'bairro' in df.columns:
-    bairros_validos = df['bairro'].fillna('').astype(str).str.strip()
+    df_enderecos = remover_duplicatas(df, ['link', 'title', 'published_date', 'bairro'])
+    bairros_validos = df_enderecos['bairro'].fillna('').astype(str).str.strip()
     bairros_validos = bairros_validos[bairros_validos != '']
     if not bairros_validos.empty:
       bairros_normalizados = bairros_validos.apply(normalizar_endereco)

--- a/index.html
+++ b/index.html
@@ -15,6 +15,9 @@
 <section id="dashboard-panel">
   <div class="dashboard-content">
     <h2>Dashboard de ocorrências</h2>
+    <p class="dashboard-total" aria-live="polite">
+      Total de ocorrências: <strong id="dashboard-total-count">0</strong>
+    </p>
     <div class="dashboard-feedback" aria-live="polite"></div>
     <div class="dashboard-chart">
       <h3>Ocorrências por tema</h3>

--- a/script.js
+++ b/script.js
@@ -19,6 +19,7 @@ document.addEventListener('DOMContentLoaded', () => {
   let globalSelectCloseHandlerAttached = false;
   const dashboardPanel = document.getElementById('dashboard-panel');
   const dashboardFeedback = dashboardPanel ? dashboardPanel.querySelector('.dashboard-feedback') : null;
+  const dashboardTotalElement = dashboardPanel ? dashboardPanel.querySelector('#dashboard-total-count') : null;
   const API_BASE_URL = (() => {
     const meta = document.querySelector('meta[name="api-base-url"]');
     const candidates = [
@@ -632,6 +633,9 @@ document.addEventListener('DOMContentLoaded', () => {
       if (dashboardFeedback) {
         dashboardFeedback.textContent = 'Carregando estatísticas...';
       }
+      if (dashboardTotalElement) {
+        dashboardTotalElement.textContent = '...';
+      }
     } else {
       dashboardPanel.style.display = 'none';
       if (dashboardFeedback) {
@@ -791,6 +795,15 @@ document.addEventListener('DOMContentLoaded', () => {
       }
 
       const dadosDashboard = await response.json();
+      const totalOcorrenciasBruto = dadosDashboard.totalOcorrencias ?? dadosDashboard.total_ocorrencias ?? dadosDashboard.total ?? dadosDashboard.count;
+      if (dashboardTotalElement) {
+        const totalNumero = Number(totalOcorrenciasBruto);
+        if (Number.isFinite(totalNumero) && totalNumero >= 0) {
+          dashboardTotalElement.textContent = totalNumero.toLocaleString('pt-BR');
+        } else {
+          dashboardTotalElement.textContent = '0';
+        }
+      }
       const temasRaw = dadosDashboard.temas || dadosDashboard.porTema || dadosDashboard.por_tema;
       const temporalRaw = dadosDashboard.temporal || dadosDashboard.serieTemporal || dadosDashboard.serie_temporal || dadosDashboard.serie_mensal;
       const enderecosRaw = dadosDashboard.principais_enderecos || dadosDashboard.enderecos || dadosDashboard.topEnderecos;
@@ -838,6 +851,9 @@ document.addEventListener('DOMContentLoaded', () => {
       console.error('Erro ao carregar estatísticas do dashboard:', error);
       if (dashboardFeedback) {
         dashboardFeedback.textContent = 'Não foi possível carregar as estatísticas do dashboard.';
+      }
+      if (dashboardTotalElement) {
+        dashboardTotalElement.textContent = '0';
       }
     }
   }

--- a/style.css
+++ b/style.css
@@ -34,6 +34,17 @@ body, html {
   color: #1f2933;
 }
 
+#dashboard-panel .dashboard-total {
+  margin: 0;
+  font-size: 16px;
+  color: #1f2933;
+}
+
+#dashboard-panel .dashboard-total strong {
+  font-weight: 600;
+  color: #0f172a;
+}
+
 #dashboard-panel .dashboard-chart h3 {
   margin: 0 0 12px 0;
   font-size: 18px;


### PR DESCRIPTION
## Summary
- evita duplicidades nas estatísticas do dashboard ao deduplicar ocorrências na API e expõe o total agregado
- exibe no painel do dashboard o número total de ocorrências e estados de carregamento/erro
- ajusta estilos para acomodar o novo resumo no painel

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_690b8ea52ac88325955433a5307c9471